### PR TITLE
Enable file completion

### DIFF
--- a/completions/replay.fish
+++ b/completions/replay.fish
@@ -1,3 +1,2 @@
-complete --command replay --no-files
 complete --command replay --exclusive --long version --description "Print version"
 complete --command replay --exclusive --long help --description "Print help"


### PR DESCRIPTION
One of the most common use-case of `replay.fish` is to source bash file, e.g.
```sh
$ replay source ~/xxx/setup.bash
```
It's annoying to not be able to tab complete file path, and it doesn't make sense to prevent it, as anything after the `replay` command can be any valid bash script, including the use of filepath.